### PR TITLE
add click on numbers, minute display, outside numbers

### DIFF
--- a/src/Clock.jsx
+++ b/src/Clock.jsx
@@ -21,6 +21,7 @@ import {
 
 export default function Clock({
   className,
+  displayNumbersOutside,
   hourHandLength,
   hourHandOppositeLength,
   hourHandWidth,
@@ -31,6 +32,7 @@ export default function Clock({
   minuteHandWidth,
   minuteMarksLength,
   minuteMarksWidth,
+  numberSelect,
   renderHourMarks,
   renderMinuteHand,
   renderMinuteMarks,
@@ -42,6 +44,12 @@ export default function Clock({
   size,
   value,
 }) {
+  function hourMarkClickFn(event) {
+    if (numberSelect) {
+      numberSelect(event.target.textContent);
+    }
+  }
+
   function renderMinuteMarksFn() {
     if (!renderMinuteMarks) {
       return null;
@@ -73,13 +81,22 @@ export default function Clock({
 
     const hourMarks = [];
     for (let i = 1; i <= 12; i += 1) {
+      let number;
+      if (renderNumbers === 'minutes') {
+        number = i * 5;
+        number = number === 60 ? '00' : number;
+      } else if (renderNumbers) {
+        number = i;
+      }
       hourMarks.push(
         <Mark
           key={`hour_${i}`}
           angle={i * 30}
+          displayOutside={displayNumbersOutside}
           length={hourMarksLength}
           name="hour"
-          number={renderNumbers ? i : null}
+          number={number}
+          onClick={hourMarkClickFn}
           width={hourMarksWidth}
         />,
       );
@@ -197,6 +214,7 @@ Clock.propTypes = {
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
   ]),
+  displayNumbersOutside: PropTypes.bool,
   hourHandLength: isHandLength,
   hourHandOppositeLength: isOppositeHandLength,
   hourHandWidth: isHandWidth,
@@ -207,6 +225,7 @@ Clock.propTypes = {
   minuteHandWidth: isHandWidth,
   minuteMarksLength: isMarkLength,
   minuteMarksWidth: isMarkWidth,
+  numberSelect: PropTypes.func,
   renderHourMarks: PropTypes.bool,
   renderMinuteHand: PropTypes.bool,
   renderMinuteMarks: PropTypes.bool,

--- a/src/Mark.jsx
+++ b/src/Mark.jsx
@@ -5,11 +5,14 @@ import { isMarkLength, isMarkWidth } from './shared/propTypes';
 
 export default function Mark({
   angle,
+  displayOutside,
   length,
   name,
+  onClick,
   width,
   number,
 }) {
+  const numberPosition = displayOutside ? '-25px' : `${length / 2}%`;
   return (
     <div
       className={`react-clock__mark react-clock__${name}-mark`}
@@ -26,12 +29,18 @@ export default function Mark({
         }}
       />
       {number && (
+        /* eslint-disable jsx-a11y/click-events-have-key-events */
+        /* eslint-disable jsx-a11y/no-static-element-interactions */
+        /* the clock is specifically for sighted/mouse users to interact with */
         <div
           className="react-clock__mark__number"
+          onClick={onClick}
           style={{
+            cursor: 'pointer',
             transform: `rotate(-${angle}deg)`,
-            top: `${length / 2}%`,
+            top: numberPosition,
           }}
+          tabIndex="-1"
         >
           {number}
         </div>
@@ -48,8 +57,10 @@ Mark.defaultProps = {
 
 Mark.propTypes = {
   angle: PropTypes.number,
+  displayOutside: PropTypes.bool,
   length: isMarkLength,
   name: PropTypes.string.isRequired,
   number: PropTypes.number,
+  onClick: PropTypes.func,
   width: isMarkWidth,
 };


### PR DESCRIPTION
add options for:
- a callback function when a mark is clicked
- displaying minute numbers instead of hours
- moving the numbers outside of the clock face instead of inside
-- this makes them easier to click